### PR TITLE
Pay from credit

### DIFF
--- a/plugin.video.cinetree/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.cinetree/resources/language/resource.language.en_gb/strings.po
@@ -90,7 +90,7 @@ msgid "Rental film"
 msgstr ""
 
 msgctxt "#30602"
-msgid "You can watch this film after you´ve paid the rent via the Cinetree website, or the official Cinetree Apple/Android app."
+msgid "Your balance of € {credit:0.2f} is not sufficient to pay the rental price of € {amount:0.2f}.\nPlease top up your credit at Cinetree or pay the rent on the Cinetree website, or the official Cinetree Apple/Android app."
 msgstr ""
 
 msgctxt "#30604"
@@ -98,10 +98,10 @@ msgid "More info"
 msgstr ""
 
 msgctxt "#30605"
-msgid "Unfortunately, it is not possible to pay for a film directly from kodi.\n\n"
-"You must first rent the film on the Cinetree website, or by using the official Cinetree Android or iOS app. "
+msgid "Charging the rent to your pre-paid credit with Cinetree is only payment method supported by this Kodi add-on.\n\n"
+"For additional payment methods use the Cinetree website, or the official Cinetree Android or iOS app. "
 "Usually it is easiest to goto 'Huur' on the website and make a search on the film title. Click on 'Nu kijken' and "
-"make the payment. Now you can close the web browser and watch the film from kodi.\n\nAll rented films are available "
+"make the payment. Once paid you can close the web browser and watch the film from Kodi.\n\nAll rented films are available "
 "in the menu 'My Films > Rented' for the duration of the rental period."
 msgstr ""
 
@@ -169,6 +169,19 @@ msgstr ""
 msgctxt "#30621"
 msgid "Login now"
 msgstr ""
+
+msgctxt "#30622"
+msgid "Rent Film"
+msgstr ""
+
+msgctxt "#30623"
+msgid "Rent '{title}' now?\nPrice: € {amount:0.2f}\nCurrent credit: € {credit:0.2f}."
+msgstr ""
+
+msgctxt "#30624"
+msgid "Pay"
+msgstr ""
+
 
 # Generic button texts
 msgctxt "#30790"

--- a/plugin.video.cinetree/resources/language/resource.language.nl_nl/strings.po
+++ b/plugin.video.cinetree/resources/language/resource.language.nl_nl/strings.po
@@ -84,23 +84,23 @@ msgid "Rental film"
 msgstr "Huurfilm"
 
 msgctxt "#30602"
-msgid "You can watch this film after you´ve paid the rent via the Cinetree website, or the official Cinetree Apple/Android app."
-msgstr "U kunt deze film bekijken nadat u het huurbedrag hebt voldaan via de Cinetree-website of de officiële Cinetree Apple/Android app."
+msgid "Your balance of € {credit:0.2f} is not sufficient to pay the rental price of € {amount:0.2f}.\nPlease top up your credit at Cinetree or pay the rent on the Cinetree website, or the official Cinetree Apple/Android app."
+msgstr "Je tegoed van € {credit:0.2f} is niet toerijkend om het huurbedrag van € {amount:0.2f} te voldoen. Vul je tegoed bij Cinetree aan of betaal de huur op de Cinetree-website of de officiële Cinetree Apple/Android app."
 
 msgctxt "#30604"
 msgid "More info"
 msgstr "Meer Informatie"
 
 msgctxt "#30605"
-msgid "Unfortunately, it is not possible to pay for a film directly from kodi.\n\n"
-"You must first rent the film on the Cinetree website, or by using the official Cinetree Android or iOS app. "
+msgid "Charging the rent to your pre-paid credit with Cinetree is only payment method supported by this Kodi add-on.\n\n"
+"For additional payment methods use the Cinetree website, or the official Cinetree Android or iOS app. "
 "Usually it is easiest to goto 'Huur' on the website and make a search on the film title. Click on 'Nu kijken' and "
-"make the payment. Now you can close the web browser and watch the film from kodi.\n\nAll rented films are available "
+"make the payment. Once paid you can close the web browser and watch the film from Kodi.\n\nAll rented films are available "
 "in the menu 'My Films > Rented' for the duration of the rental period."
-msgstr "Helaas is het niet mogelijk om het huurbedrag te voldoen vanuit kodi.\n\n"
-"Je moet eerst de film huren via de cinetree-website of met de officiële Android of iOS app. Het is meestal het "
+msgstr "Via deze Kodi addon kan je alleen direct betalen met je Cinetree tegoed.\n\n"
+"Andere betaalmethodes zijn beschikbaar op de cinetree-website of de officiële Android of iOS app. Het is meestal het "
 "makkelijkste om op de website naar 'huur' te gaan en daar de film op titel te zoeken. Klik daarna op 'Nu kijken' "
-"en doe de betaling. Daarna kan je de browser sluiten en kan je de film vanuit kodi bekijken.\n\nAlle gehuurde films "
+"en doe de betaling. Nadat de film is betaald kan je hem vanuit kodi bekijken.\nAlle gehuurde films "
 "zijn gedurende de huurperiode beschikbaar via het menu 'Mijn Films > Gehuurd'."
 
 msgctxt "#30606"
@@ -168,6 +168,19 @@ msgstr "Speel vanaf het begin"
 msgctxt "#30621"
 msgid "Login now"
 msgstr "Nu inloggen"
+
+msgctxt "#30622"
+msgid "Rent Film"
+msgstr "Huur Film"
+
+msgctxt "#30623"
+msgid "Rent '{title}' now?\nPrice: € {amount:0.2f}\nCurrent credit: € {credit:0.2f}."
+msgstr "Nu '{title}' huren?\nHuurbedrag: € {amount:0.2f}\nHuidig tegoed: € {credit:0.2f}."
+
+msgctxt "#30624"
+msgid "Pay"
+msgstr "Betaal"
+
 
 # Generic button texts
 msgctxt "#30790"

--- a/plugin.video.cinetree/resources/lib/ctree/ct_api.py
+++ b/plugin.video.cinetree/resources/lib/ctree/ct_api.py
@@ -310,6 +310,7 @@ def pay_film(film_uid, film_title, transaction_id, price):
         if content:
             logger.warning("pay_film - Unexpected response content: '%s'", content)
         # On success cinetree returns 200 OK without content.
+        logger.info("Paid %0.2f from cinetree credit for film '%'")
         return resp.status_code == 200
     except:
         logger.error("[ct_api.pay_film] paying failed: film_uid=%s, film_title=%s, trans_id=%s, price=%s\n",

--- a/plugin.video.cinetree/resources/lib/kodi_utils.py
+++ b/plugin.video.cinetree/resources/lib/kodi_utils.py
@@ -230,7 +230,7 @@ def confirm_rent_from_credit(title, price, credit):
                        Script.localize(BTN_TXT_CANCEL),
                        Script.localize(TXT_PAY))
     if not result:
-        ok_dialog(TXT_MORE_INFO)
+        dlg.textviewer(Script.localize(TXT_RENTAL_FILM), Script.localize(MSG_MORE_PAYMENT_INFO))
     return result
 
 

--- a/plugin.video.cinetree/resources/lib/kodi_utils.py
+++ b/plugin.video.cinetree/resources/lib/kodi_utils.py
@@ -24,7 +24,7 @@ TXT_LOG_TARGETS = 30112
 TXT_CINETREE_ACCOUNT = 30200
 
 TXT_RENTAL_FILM = 30601
-MSG_PAY_INFO = 30602
+MSG_CREDITS_LOW = 30602
 TXT_MORE_INFO = 30604
 MSG_MORE_PAYMENT_INFO = 30605
 TXT_ACCOUNT_ERROR = 30610
@@ -40,6 +40,10 @@ TXT_TRY_AGAIN = 30618
 TXT_RESUME_FROM = 30619
 TXT_PLAY_FROM_START = 30620
 TXT_LOGIN_NOW = 30621
+
+TXT_RENT_NOW = 30622
+MSG_RENT_NOW_CONFIRM = 30623
+TXT_PAY = 30624
 
 BTN_TXT_OK = 30790
 BTN_TXT_CANCEL = 30791
@@ -168,7 +172,7 @@ def ask_login_retry(reason):
             yeslabel=Script.localize(BTN_TXT_OK))
 
 
-def show_rental_msg(title=None, price=None):
+def show_low_credit_msg(price, credit):
     """Show a message with info regarding rental films
 
     Note that the NO-button acts as an OK button.
@@ -178,7 +182,7 @@ def show_rental_msg(title=None, price=None):
     dlg = xbmcgui.Dialog()
     result = dlg.yesno(
             dlg_title,
-            Script.localize(MSG_PAY_INFO),
+            Script.localize(MSG_CREDITS_LOW).format(credit=credit, amount=price),
             nolabel=Script.localize(BTN_TXT_OK),
             yeslabel=Script.localize(TXT_MORE_INFO),
             autoclose=15000)
@@ -216,3 +220,25 @@ def ask_log_handler(default):
     except IndexError:
         # default value is not necessarily a valid index.
         return result, ''
+
+
+def confirm_rent_from_credit(title, price, credit):
+    msg_txt = Script.localize(MSG_RENT_NOW_CONFIRM).format(title=title, amount=price, credit=credit)
+    dlg = xbmcgui.Dialog()
+    result = dlg.yesno(Script.localize(TXT_RENT_NOW),
+                       msg_txt,
+                       Script.localize(BTN_TXT_CANCEL),
+                       Script.localize(TXT_PAY))
+    if not result:
+        ok_dialog(TXT_MORE_INFO)
+    return result
+
+
+def ok_dialog(msg, heading=None):
+    if heading is None:
+        heading  = 'Cinetree'
+    elif isinstance(heading, int):
+        heading = Script.localize(heading)
+    if isinstance(msg, int):
+        msg = Script.localize(msg)
+    xbmcgui.Dialog().ok(heading, msg)

--- a/plugin.video.cinetree/resources/lib/main.py
+++ b/plugin.video.cinetree/resources/lib/main.py
@@ -37,6 +37,7 @@ TXT_ALREADY_WATCHED = 30808
 TXT_RENTED = 30809
 TXT_NOTHING_FOUND = 30608
 TXT_TOO_MANY_RESULTS = 30609
+MSG_PAYMENT_FAIL = 30625
 
 
 @Route.register
@@ -316,11 +317,12 @@ def pay_from_ct_credit(title, uuid):
     ct_credits = future_objs[1].result()
     if amount > ct_credits:
         kodi_utils.show_low_credit_msg(amount, ct_credits)
-        return False
-    if kodi_utils.confirm_rent_from_credit(title, amount, ct_credits):
-        return ct_api.pay_film(uuid, title, trans_id, amount)
-    else:
-        return False
+    elif kodi_utils.confirm_rent_from_credit(title, amount, ct_credits):
+        if ct_api.pay_film(uuid, title, trans_id, amount):
+            return True
+        else:
+            kodi_utils.ok_dialog(MSG_PAYMENT_FAIL)
+    return False
 
 
 def run():

--- a/tests/local/test_ct_api.py
+++ b/tests/local/test_ct_api.py
@@ -1,18 +1,18 @@
 
 # ------------------------------------------------------------------------------
-#  Copyright (c) 2022 Dimitri Kroon
-#
-#  SPDX-License-Identifier: GPL-2.0-or-later
-#  This file is part of plugin.video.cinetree
+#  Copyright (c) 2022-2024 Dimitri Kroon.
+#  This file is part of plugin.video.cinetree.
+#  SPDX-License-Identifier: GPL-2.0-or-later.
+#  See LICENSE.txt
 # ------------------------------------------------------------------------------
+
+from tests.support import fixtures
+fixtures.global_setup()
 
 import os.path
 
 from unittest import TestCase
 from unittest.mock import patch
-
-from tests.support import fixtures
-fixtures.global_setup()
 
 from tests.support.testutils import open_jsonp, open_doc, open_json, HttpResponse
 from tests.support.object_checks import check_collection
@@ -156,9 +156,15 @@ class Gen(TestCase):
         self.assertEqual(cur_credits, 6.51)
 
     def test_pay_film(self):
-        with patch('resources.lib.fetch.fetch_authenticated', return_value=HttpResponse(200)):
+        with patch('resources.lib.fetch.fetch_authenticated', return_value=HttpResponse(content=b'')):
             result = ct_api.pay_film('my-film-uuid', 'film-title', 'ddskfkj6593498u', 3.49)
             self.assertIs(result, True)
-        with patch('resources.lib.fetch.fetch_authenticated', return_value=HttpResponse(400)):
+        with patch('resources.lib.fetch.fetch_authenticated', return_value=HttpResponse(content=b'some text')):
+            result = ct_api.pay_film('my-film-uuid', 'film-title', 'ddskfkj6593498u', 3.49)
+            self.assertIs(result, True)
+        with patch('resources.lib.fetch.fetch_authenticated', return_value=HttpResponse(400, content=b'')):
+            result = ct_api.pay_film('my-film-uuid', 'film-title', 'ddskfkj6593498u', 3.49)
+            self.assertIs(result, False)
+        with patch('resources.lib.fetch.fetch_authenticated', side_effect=errors.HttpError):
             result = ct_api.pay_film('my-film-uuid', 'film-title', 'ddskfkj6593498u', 3.49)
             self.assertIs(result, False)

--- a/tests/local/test_kodi_utils.py
+++ b/tests/local/test_kodi_utils.py
@@ -49,12 +49,12 @@ class TestKodiUtils(unittest.TestCase):
             self.assertFalse(kodi_utils.ask_login_retry('Invalid password'))
 
     @patch('xbmcgui.Dialog.textviewer')
-    def test_show_rental_msg(self, p_viewer):
+    def test_show_low_credits_msg(self, p_viewer):
         with patch('xbmcgui.Dialog.yesno', return_value=False):
-            self.assertIsNone(kodi_utils.show_rental_msg())
+            self.assertIsNone(kodi_utils.show_low_credit_msg(0.0, 3.25))
             p_viewer.asser_not_called()
         with patch('xbmcgui.Dialog.yesno', return_value=True):
-            self.assertIsNone(kodi_utils.show_rental_msg())
+            self.assertIsNone(kodi_utils.show_low_credit_msg(0, 3.25))
             p_viewer.asser_called_once()
 
     @patch('xbmcgui.Dialog.contextmenu')
@@ -78,3 +78,15 @@ class TestKodiUtils(unittest.TestCase):
             result, name = kodi_utils.ask_log_handler(5)
             self.assertEqual(5, result)
             self.assertEqual('', name)
+
+    @patch('xbmcgui.Dialog.ok')
+    def test_confirm_rent_from_credit(self, p_dlg_ok):
+        with patch('xbmcgui.Dialog.yesno', return_value=True):
+            result = kodi_utils.confirm_rent_from_credit('some film', 2.49, 10.0)
+            self.assertIs(result, True)
+            p_dlg_ok.assert_not_called()
+
+        with patch('xbmcgui.Dialog.yesno', return_value=False):
+            result = kodi_utils.confirm_rent_from_credit('some film', 2.49, 10.0)
+            self.assertIs(result, False)
+            p_dlg_ok.assert_called_once()

--- a/tests/local/test_kodi_utils.py
+++ b/tests/local/test_kodi_utils.py
@@ -1,9 +1,9 @@
 
 # ------------------------------------------------------------------------------
-#  Copyright (c) 2022 Dimitri Kroon
-#
-#  SPDX-License-Identifier: GPL-2.0-or-later
-#  This file is part of plugin.video.cinetree
+#  Copyright (c) 2022-2024 Dimitri Kroon.
+#  This file is part of plugin.video.cinetree.
+#  SPDX-License-Identifier: GPL-2.0-or-later.
+#  See LICENSE.txt
 # ------------------------------------------------------------------------------
 
 import unittest
@@ -79,14 +79,14 @@ class TestKodiUtils(unittest.TestCase):
             self.assertEqual(5, result)
             self.assertEqual('', name)
 
-    @patch('xbmcgui.Dialog.ok')
-    def test_confirm_rent_from_credit(self, p_dlg_ok):
+    @patch('xbmcgui.Dialog.textviewer')
+    def test_confirm_rent_from_credit(self, p_dlg):
         with patch('xbmcgui.Dialog.yesno', return_value=True):
             result = kodi_utils.confirm_rent_from_credit('some film', 2.49, 10.0)
             self.assertIs(result, True)
-            p_dlg_ok.assert_not_called()
+            p_dlg.assert_not_called()
 
         with patch('xbmcgui.Dialog.yesno', return_value=False):
             result = kodi_utils.confirm_rent_from_credit('some film', 2.49, 10.0)
             self.assertIs(result, False)
-            p_dlg_ok.assert_called_once()
+            p_dlg.assert_called_once()

--- a/tests/local/test_main.py
+++ b/tests/local/test_main.py
@@ -159,53 +159,6 @@ class MainTest(unittest.TestCase):
             with patch('resources.lib.ctree.ct_api.get_subtitles', return_value='my_subtitle.srt'):
                 self.assertIs(main.play_ct_video(stream_inf), False)
 
-    def test_play_film_from_uuid(self):
-        with patch('resources.lib.ctree.ct_api.get_stream_info', return_value=open_json('stream_info.json')):
-            with patch("resources.lib.ctree.ct_api.get_subtitles", return_value=None):
-                playitem = main.play_film(MagicMock(), '', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
-                self.assertIsInstance(playitem, xbmcgui.ListItem)
-        with patch('resources.lib.ctree.ct_api.get_stream_info', side_effect=errors.NotPaidError):
-            playitem = main.play_film(MagicMock(), '', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
-            self.assertFalse(playitem)
-        with patch('resources.lib.ctree.ct_api.get_stream_info', side_effect=errors.NoSubscriptionError):
-            playitem = main.play_film(MagicMock(), '', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
-            self.assertFalse(playitem)
-        with patch('resources.lib.ctree.ct_api.get_stream_info', side_effect=errors.HttpError(404, '')):
-            playitem = main.play_film(MagicMock(), '', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
-            self.assertFalse(playitem)
-        with patch('resources.lib.ctree.ct_api.get_stream_info', side_effect=errors.FetchError):
-            playitem = main.play_film(MagicMock(), '', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
-            self.assertFalse(playitem)
-        with patch('resources.lib.ctree.ct_api.get_stream_info', side_effect=ValueError):
-            playitem = main.play_film(MagicMock(), '', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
-            self.assertIsInstance(playitem, type(False))
-
-    @patch("resources.lib.ctree.ct_api.get_subtitles", return_value=None)
-    def test_play_film_resume_time(self, _):
-        strm_info = open_json('stream_info.json')
-        strm_info['playtime'] = 1560.236
-        with patch('resources.lib.ctree.ct_api.get_stream_info', return_value=strm_info):
-            main.play_film(MagicMock(), '', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
-        strm_info['playtime'] = 0
-        with patch('resources.lib.ctree.ct_api.get_stream_info', return_value=strm_info):
-            main.play_film(MagicMock(), '', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
-        del strm_info['playtime']
-        with patch('resources.lib.ctree.ct_api.get_stream_info', return_value=strm_info):
-            main.play_film(MagicMock(), '', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
-
-    @patch("resources.lib.ctree.ct_api.get_subtitles", return_value=None)
-    @patch('resources.lib.ctree.ct_api.get_stream_info', return_value=open_json('stream_info.json'))
-    def test_play_film_resume_dialog_result(self, _, __):
-        with patch('resources.lib.kodi_utils.ask_resume_film', return_value=0):
-            item = main.play_film(MagicMock(), '', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
-            self.assertIsInstance(item, xbmcgui.ListItem)
-        with patch('resources.lib.kodi_utils.ask_resume_film', return_value=1):
-            item = main.play_film(MagicMock(), '', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
-            self.assertIsInstance(item, xbmcgui.ListItem)
-        with patch('resources.lib.kodi_utils.ask_resume_film', return_value=-1):
-            item = main.play_film(MagicMock(), '', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
-            self.assertIsInstance(item, type(False))
-
     def test_play_trailer(self):
         # trailer form YouTube
         plugin = MagicMock()
@@ -230,3 +183,101 @@ class MainTest(unittest.TestCase):
         # trailer from something else
         item = main.play_trailer(plugin, "https://cloud.com/bla/bla")
         self.assertFalse(item)
+
+
+@patch("resources.lib.ctree.ct_api.get_subtitles", return_value=None)
+class PlayFilm(unittest.TestCase):
+    @patch('resources.lib.main.pay_from_ct_credit', return_value=False)
+    def test_play_film_from_uuid(self, p_pay_from_credit, _):
+        with patch('resources.lib.ctree.ct_api.get_stream_info', return_value=open_json('stream_info.json')):
+            playitem = main.play_film.test('', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
+            self.assertIsInstance(playitem, xbmcgui.ListItem)
+            p_pay_from_credit.assert_not_called()
+        with patch('resources.lib.ctree.ct_api.get_stream_info', side_effect=errors.NotPaidError):
+            playitem = main.play_film.test('', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
+            self.assertFalse(playitem)
+            p_pay_from_credit.assert_called_once()
+        p_pay_from_credit.reset_mock()
+        with patch('resources.lib.ctree.ct_api.get_stream_info', side_effect=errors.NoSubscriptionError):
+            playitem = main.play_film.test('', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
+            self.assertFalse(playitem)
+            p_pay_from_credit.assert_not_called()
+        with patch('resources.lib.ctree.ct_api.get_stream_info', side_effect=errors.HttpError(404, '')):
+            playitem = main.play_film.test('', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
+            self.assertFalse(playitem)
+            p_pay_from_credit.assert_not_called()
+        with patch('resources.lib.ctree.ct_api.get_stream_info', side_effect=errors.FetchError):
+            playitem = main.play_film.test('', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
+            self.assertFalse(playitem)
+            p_pay_from_credit.assert_not_called()
+        with patch('resources.lib.ctree.ct_api.get_stream_info', side_effect=ValueError):
+            playitem = main.play_film.test('', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
+            self.assertIsInstance(playitem, type(False))
+            p_pay_from_credit.assert_not_called()
+
+    @patch('resources.lib.ctree.ct_api.get_stream_info', side_effect=(errors.NotPaidError,
+                                                                      open_json('stream_info.json')))
+    @patch('resources.lib.main.pay_from_ct_credit', return_value=True)
+    def test_play_film_after_paying(self, p_pay_from_credit, p_get_stream_info, _):
+        playitem = main.play_film.test('', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
+        self.assertIsInstance(playitem, xbmcgui.ListItem)
+        p_pay_from_credit.assert_called_once()
+        self.assertEqual(2, p_get_stream_info.call_count)
+
+    def test_play_film_resume_time(self, _):
+        strm_info = open_json('stream_info.json')
+        strm_info['playtime'] = 1560.236
+        with patch('resources.lib.ctree.ct_api.get_stream_info', return_value=strm_info):
+            main.play_film.test('', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
+        strm_info['playtime'] = 0
+        with patch('resources.lib.ctree.ct_api.get_stream_info', return_value=strm_info):
+            main.play_film.test('', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
+        del strm_info['playtime']
+        with patch('resources.lib.ctree.ct_api.get_stream_info', return_value=strm_info):
+            main.play_film.test('', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
+
+    @patch('resources.lib.ctree.ct_api.get_stream_info', return_value=open_json('stream_info.json'))
+    def test_play_film_resume_dialog_result(self, _, __):
+        with patch('resources.lib.kodi_utils.ask_resume_film', return_value=0):
+            item = main.play_film.test('', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
+            self.assertIsInstance(item, xbmcgui.ListItem)
+        with patch('resources.lib.kodi_utils.ask_resume_film', return_value=1):
+            item = main.play_film.test('', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
+            self.assertIsInstance(item, xbmcgui.ListItem)
+        with patch('resources.lib.kodi_utils.ask_resume_film', return_value=-1):
+            item = main.play_film.test('', 'ec0407a8-24a1-47a1-8bbf-61ada5f6610f', None)
+            self.assertIsInstance(item, type(False))
+
+
+
+@patch('resources.lib.kodi_utils.show_low_credit_msg')
+class PayFromCredit(unittest.TestCase):
+    @patch('resources.lib.ctree.ct_api.pay_film', return_value=True)
+    @patch('resources.lib.ctree.ct_api.get_payment_info', return_value=(4.3, '1982873hfmalk'))
+    @patch('resources.lib.ctree.ct_api.get_ct_credits', return_value=10)
+    def test_pay_successfully(self, _, __, p_pay_film, p_show_low_credit):
+        with patch('resources.lib.kodi_utils.confirm_rent_from_credit', return_value=True):
+            result = main.pay_from_ct_credit('my_film', 'my-film-uuid')
+            self.assertIs(result, True)
+            p_show_low_credit.assert_not_called()
+            p_pay_film.assert_called_once()
+
+    @patch('resources.lib.ctree.ct_api.pay_film', return_value=True)
+    @patch('resources.lib.ctree.ct_api.get_payment_info', return_value=(4.3, '1982873hfmalk'))
+    @patch('resources.lib.ctree.ct_api.get_ct_credits', return_value=10)
+    def test_pay_canceled(self, _, __, p_pay_film, p_show_low_credit):
+        with patch('resources.lib.kodi_utils.confirm_rent_from_credit', return_value=False):
+            result = main.pay_from_ct_credit('my_film', 'my-film-uuid')
+            self.assertIs(result, False)
+            p_show_low_credit.assert_not_called()
+            p_pay_film.assert_not_called()
+
+
+    @patch('resources.lib.ctree.ct_api.pay_film', return_value=True)
+    @patch('resources.lib.ctree.ct_api.get_payment_info', return_value=(4.3, '1982873hfmalk'))
+    @patch('resources.lib.ctree.ct_api.get_ct_credits', return_value=2)
+    def test_not_enough_credit(self, _, __, p_pay_film, p_show_low_credit):
+        result = main.pay_from_ct_credit('my_film', 'my-film-uuid')
+        self.assertIs(result, False)
+        p_show_low_credit.assert_called_once()
+        p_pay_film.assert_not_called()

--- a/tests/test_docs/me.json
+++ b/tests/test_docs/me.json
@@ -1,0 +1,40 @@
+{
+  "_id": "62f562e1aa6f5ce58bfe241f",
+  "email": "dimitri@kroonmail.nl",
+  "name": {
+    "first": "Dimitri",
+    "last": "Kroon"
+  },
+  "displayName": "Dimitri Kroon",
+  "campaign": "",
+  "promotionCode": "",
+  "subscription": null,
+  "subscriptionValidTo": null,
+  "purchased": [
+    "ef51ee02-0635-4547-a35d-d7844e0c5426",
+    "7e159079-d2cc-428a-8291-8c8c27c564c1",
+    "bd209a8e-2bd3-4916-b5bc-053c9633ee96",
+    "e6e121fb-b366-4717-a487-374db8c01a63",
+    "b4cde666-d4be-4d94-b19b-e512f74459a2",
+    "149386b3-fdcb-4e68-8d45-08238014c658"
+  ],
+  "emailVerified": true,
+  "emailVerificationSentAt": "2022-08-11T20:13:22.245Z",
+  "settings": {
+    "popups": [
+      "It's a lovestory Olivia",
+      "Gaite Jansen Hollands Glorie",
+      "Giftcard pop up 1",
+      "FFF pop-up"
+    ]
+  },
+  "credit": 6.51,
+  "filmGenres": [],
+  "partition": 0.410939598735547,
+  "currentSubscription": null,
+  "renewalSubscription": null,
+  "subscribedToNewsletter": false,
+  "favorites": [],
+  "showContinueWatching": true,
+  "firebase": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJodHRwczovL2lkZW50aXR5dG9vbGtpdC5nb29nbGVhcGlzLmNvbS9nb29nbGUuaWRlbnRpdHkuaWRlbnRpdHl0b29sa2l0LnYxLklkZW50aXR5VG9vbGtpdCIsImlhdCI6MTczMDk5ODU2OSwiZXhwIjoxNzMxMDAyMTY5LCJpc3MiOiJmaXJlYmFzZS1hZG1pbnNkay1rOHZhbkBjaW5ldHJlZS1hcHBzLmlhbS5nc2VydmljZWFjY291bnQuY29tIiwic3ViIjoiZmlyZWJhc2UtYWRtaW5zZGstazh2YW5AY2luZXRyZWUtYXBwcy5pYW0uZ3NlcnZpY2VhY2NvdW50LmNvbSIsInVpZCI6IjYyZjU2MmUxYWE2ZjVjZTU4YmZlMjQxZiIsImNsYWltcyI6eyJkaXNwbGF5TmFtZSI6IkRpbWl0cmkgS3Jvb24ifX0.L5ooXFCR2B5U4huTnoMb0LZWWEBCzeXoe90Nq7v1GJfS1cULrF_AofxA4rVI2M5vk3KskLxpP4rQ8AUQ7nbBHiXx_nQsBlZKfk8yopBB1OmUQxtzP65wOEsDxe0XCeblXAQCNLH7DdruLAGr_SDldpFLWmT6SNK9u5_7JWRh9zCgObI91Mdr6a5rv76WchWtyjjyfHeW15fp6zU0tg_XNNtkoCB4VqjKLjSc7Mm4t3UrCCS5-JxIHDd6JQXEmJmHzh61VsMkPcWWgbdASTzWDdW1YqT3SLjZYkZIif9U6Ut-vfMgl4TD8--OJWH6fgd_nm3Kc0hEEdZGHj9dTIQ61A"
+}

--- a/tests/test_docs/payment_info.json
+++ b/tests/test_docs/payment_info.json
@@ -1,0 +1,104 @@
+{
+  "applePayProductId": "rental3.49",
+  "transaction": "672cf124ab1c8075b5437d10",
+  "amount": 3.49,
+  "directory": {
+    "paymentMethods": [
+      {
+        "issuers": [
+          {
+            "id": "0721",
+            "name": "ING",
+            "issuerId": "0721"
+          },
+          {
+            "id": "0021",
+            "name": "Rabobank",
+            "issuerId": "0021"
+          },
+          {
+            "id": "0031",
+            "name": "ABN Amro",
+            "issuerId": "0031"
+          },
+          {
+            "id": "0751",
+            "name": "SNS Bank",
+            "issuerId": "0751"
+          },
+          {
+            "id": "0761",
+            "name": "ASN Bank",
+            "issuerId": "0761"
+          },
+          {
+            "id": "0771",
+            "name": "RegioBank",
+            "issuerId": "0771"
+          },
+          {
+            "id": "0801",
+            "name": "Knab",
+            "issuerId": "0801"
+          },
+          {
+            "id": "0802",
+            "name": "bunq",
+            "issuerId": "0802"
+          },
+          {
+            "id": "0511",
+            "name": "Triodos Bank",
+            "issuerId": "0511"
+          },
+          {
+            "id": "0805",
+            "name": "Revolut",
+            "issuerId": "0805"
+          },
+          {
+            "id": "0161",
+            "name": "Van Lanschot Kempen",
+            "issuerId": "0161"
+          },
+          {
+            "id": "0806",
+            "name": "Yoursafe",
+            "issuerId": "0806"
+          },
+          {
+            "id": "0807",
+            "name": "N26",
+            "issuerId": "0807"
+          },
+          {
+            "id": "0808",
+            "name": "Nationale-Nederlanden",
+            "issuerId": "0808"
+          }
+        ],
+        "name": "iDEAL",
+        "type": "ideal",
+        "brandCode": "ideal"
+      },
+      {
+        "brands": [
+          "mc",
+          "visa",
+          "amex"
+        ],
+        "name": "Credit Card",
+        "type": "scheme"
+      },
+      {
+        "brand": "genericgiftcard",
+        "name": "Generic GiftCard",
+        "type": "giftcard"
+      },
+      {
+        "name": "SEPA Direct Debit",
+        "type": "sepadirectdebit"
+      }
+    ]
+  }
+}

--- a/tests/web/test_cinetree.py
+++ b/tests/web/test_cinetree.py
@@ -123,8 +123,13 @@ class Gen(TestCase):
         resp = ct_api.get_rented_films()
         check_films_data_list(resp, allow_none_values=False)
 
-    def get_stream_info(self):
+    def test_get_stream_info(self):
         resp = ct_api.get_stream_info()
+
+    def test_get_payment_info(self):
+        amount, transaction = ct_api.get_payment_info('ef51ee02-0635-4547-a35d-d7844e0c5426')
+        self.assertGreater(amount, 0.0)
+        self.assertIsInstance(transaction, str)
 
 
 class SearchFilm(TestCase):

--- a/tests/web/test_cinetree_api.py
+++ b/tests/web/test_cinetree_api.py
@@ -217,3 +217,28 @@ class FetchSubtitles(unittest.TestCase):
         # with open('test_docs/subtitle-film-you_were_never_really_here.vtt', 'w') as f:
         #     f.write(resp.text)
         # pass
+
+
+class GetPaymentInfo(unittest.TestCase):
+    base_url = 'https://api.cinetree.nl/payments/info/rental/'
+
+    def test_payment_info_data(self):
+        film_uuid = 'ef51ee02-0635-4547-a35d-d7844e0c5426'
+        resp = fetch.fetch_authenticated(fetch.post_json, self.base_url + film_uuid, data=None)
+        self.assertIsInstance(resp['amount'], float)
+        transaction_id = resp['transaction']
+        self.assertIsInstance(transaction_id, str)
+        self.assertEqual(len(transaction_id), 24)
+        self.assertTrue(transaction_id.isalnum())
+
+
+class GetMeData(unittest.TestCase):
+    """Data returned by an authenticated request to /me
+
+    Currently only used to obtain the amount of credit, but this checks some other fields as well.
+    """
+    def test_me_data(self):
+        resp = fetch.fetch_authenticated(fetch.get_json, 'https://api.cinetree.nl/me')
+        object_checks.has_keys(resp, 'name', 'displayName', 'subscription', 'purchased', 'credit',
+                               'currentSubscription', 'renewalSubscription', 'favorites')
+        self.assertIsInstance(resp['credit'], float)


### PR DESCRIPTION
Implemented renting films directly from the plugin by charging the rent from your pre-paid credit at Cinetree.

Replaces #6