### PR TITLE
Sort genres at backend.

### DIFF
--- a/plugin.video.cinetree/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.cinetree/resources/language/resource.language.en_gb/strings.po
@@ -30,7 +30,7 @@ msgid "Genres sorting"
 msgstr ""
 
 msgctxt "#30106"
-msgid "Sort method"
+msgid "Sort by"
 msgstr ""
 
 msgctxt "#30107"

--- a/plugin.video.cinetree/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.cinetree/resources/language/resource.language.en_gb/strings.po
@@ -25,6 +25,18 @@ msgctxt "#30104"
 msgid "Prefer original trailer"
 msgstr ""
 
+msgctxt "#30105"
+msgid "Genres sorting"
+msgstr ""
+
+msgctxt "#30106"
+msgid "Sort method"
+msgstr ""
+
+msgctxt "#30107"
+msgid "Sort order"
+msgstr ""
+
 msgctxt "#30110"
 msgid "Logging"
 msgstr ""

--- a/plugin.video.cinetree/resources/language/resource.language.nl_nl/strings.po
+++ b/plugin.video.cinetree/resources/language/resource.language.nl_nl/strings.po
@@ -25,6 +25,18 @@ msgctxt "#30104"
 msgid "Prefer original trailer"
 msgstr "Geef voorkeur aan originele trailer"
 
+msgctxt "#30105"
+msgid "Genres sorting"
+msgstr "Genres sortering"
+
+msgctxt "#30106"
+msgid "Sort by"
+msgstr "Sorter op"
+
+msgctxt "#30107"
+msgid "Sort order"
+msgstr "Sorteer volgorde"
+
 msgctxt "#30110"
 msgid "Logging"
 msgstr ""

--- a/plugin.video.cinetree/resources/lib/main.py
+++ b/plugin.video.cinetree/resources/lib/main.py
@@ -249,9 +249,17 @@ def list_films_by_collection(addon, slug):
 
 @Route.register(content_type='movies')
 def list_films_by_genre(addon, genre, page=1):
+    sort_by = addon.setting.get_int('genre-sort-method')
+    sort_order = addon.setting.get_int('genre-sort-order')
+    logger.debug("*** Genre %s, pag %s, sorted by %s:%r", genre, page, sort_by, repr(sort_order))
+    addon.add_sort_methods(xbmcplugin.SORT_METHOD_NONE, disable_autosort=True)
     list_len = 50
-    films, num_films = storyblok.search(genre=genre, page=page, items_per_page=list_len)
-    yield from _create_playables(addon, (ct_data.FilmItem(film) for film in films))
+    films, num_films = storyblok.search(genre=genre,
+                                        page=page,
+                                        items_per_page=list_len,
+                                        sort_method=sort_by,
+                                        sort_order=sort_order)
+    yield from _create_playables(None, (ct_data.FilmItem(film) for film in films))
     if num_films > page * list_len:
         yield Listitem.next_page(genre=genre, page=page + 1)
 

--- a/plugin.video.cinetree/resources/lib/main.py
+++ b/plugin.video.cinetree/resources/lib/main.py
@@ -30,7 +30,8 @@ from resources.lib import utils
 
 logger.critical('-------------------------------------')
 
-
+TXT_SORT_BY = 30106
+TXT_SORT_ORDER = 30107
 MSG_FILM_NOT_AVAILABLE = 30606
 MSG_ONLY_WITH_SUBSCRIPTION = 30607
 TXT_MY_FILMS = 30801
@@ -259,7 +260,16 @@ def list_films_by_genre(addon, genre, page=1):
                                         items_per_page=list_len,
                                         sort_method=sort_by,
                                         sort_order=sort_order)
-    yield from _create_playables(None, (ct_data.FilmItem(film) for film in films))
+    # Context menu item to set the sort method and sort order for all genres.
+    ctx_sort_by = (
+        addon.localize(TXT_SORT_BY) + '    >>',
+        ''.join(('RunPlugin(plugin://',
+                 utils.addon_info['id'],
+                 '/resources/lib/settings/genre_sort_method)'))
+    )
+    for li in _create_playables(None, (ct_data.FilmItem(film) for film in films)):
+        li.context.insert(0, ctx_sort_by)
+        yield li
     if num_films > page * list_len:
         yield Listitem.next_page(genre=genre, page=page + 1)
 

--- a/plugin.video.cinetree/resources/lib/settings.py
+++ b/plugin.video.cinetree/resources/lib/settings.py
@@ -8,6 +8,9 @@
 
 import logging
 
+import xbmc
+import xbmcgui
+import xbmcplugin
 from codequick import Script
 from codequick.support import addon_data, logger_id
 
@@ -53,3 +56,37 @@ def change_logger(_):
 
     ct_logging.set_log_handler(handler_type)
     addon_data.setSettingString('log-handler', handler_name)
+
+
+@Script.register()
+def genre_sort_method(_):
+    """Change the settings for genre sorting.
+
+    Handler for the context menu item 'Sort by' on items in genre listings.
+
+    Offer a context menu where the user can select from several sort methods
+    and sort directions, and set the addon's settings accordingly.
+
+    """
+    ASCENDING = 0
+    DESCENDING = 1
+    TXT_ASC = Script.localize(584)
+    TXT_DESC = Script.localize(585)
+    sort_methods = [
+        (Script.localize(571), xbmcplugin.SORT_METHOD_UNSORTED, ASCENDING),
+        (' - '.join((Script.localize(556), TXT_ASC)), xbmcplugin.SORT_METHOD_TITLE, ASCENDING),
+        (' - '.join((Script.localize(556), TXT_DESC)), xbmcplugin.SORT_METHOD_TITLE, DESCENDING),
+        (' - '.join((Script.localize(570), TXT_ASC)), xbmcplugin.SORT_METHOD_DATEADDED, ASCENDING),
+        (' - '.join((Script.localize(570), TXT_DESC)), xbmcplugin.SORT_METHOD_DATEADDED, DESCENDING),
+        (' - '.join((Script.localize(180), TXT_ASC)), xbmcplugin.SORT_METHOD_DURATION, ASCENDING),
+        (' - '.join((Script.localize(180), TXT_DESC)), xbmcplugin.SORT_METHOD_DURATION, DESCENDING),
+        (' - '.join((Script.localize(562), TXT_ASC)), xbmcplugin.SORT_METHOD_VIDEO_YEAR, ASCENDING),
+        (' - '.join((Script.localize(562), TXT_DESC)), xbmcplugin.SORT_METHOD_VIDEO_YEAR, DESCENDING)
+    ]
+    dlg = xbmcgui.Dialog()
+    result = dlg.contextmenu([m[0] for m in sort_methods])
+    if result < 0:
+        return
+    addon_data.setSettingInt('genre-sort-method', sort_methods[result][1])
+    addon_data.setSettingInt('genre-sort-order', sort_methods[result][2])
+    xbmc.executebuiltin('Container.Refresh')

--- a/plugin.video.cinetree/resources/lib/storyblok.py
+++ b/plugin.video.cinetree/resources/lib/storyblok.py
@@ -11,6 +11,7 @@ import time
 import logging
 
 import urlquick
+import xbmcplugin
 from codequick.support import logger_id
 
 from resources.lib.utils import CacheMgr
@@ -145,7 +146,7 @@ def story_by_name(slug: str):
 
 
 def search(search_term=None, genre=None, duration_min=None, duration_max=None,
-           country=None, page=None, items_per_page=None):
+           country=None, page=None, items_per_page=None, sort_method=0, sort_order=0):
 
     # query_str = {'starts_with': 'films/'}
     query_str = {'filter_query[component][in]': 'film'}
@@ -169,5 +170,18 @@ def search(search_term=None, genre=None, duration_min=None, duration_max=None,
             raise ValueError("Invalid duration")
         query_str['filter_query[duration][gt_int]'] = duration_min,
         query_str['filter_query[duration][lt_int]'] = duration_max
+
+    sort_field = {
+        xbmcplugin.SORT_METHOD_DURATION: 'content.duration',
+        xbmcplugin.SORT_METHOD_DATEADDED: 'content.startDate',
+        xbmcplugin.SORT_METHOD_TITLE: 'content.title',
+        xbmcplugin.SORT_METHOD_VIDEO_YEAR: 'content.productionYear'
+    }.get(sort_method)
+    if sort_field is not None:
+        order = 'asc' if sort_order == 0 else 'desc'
+        if sort_method == xbmcplugin.SORT_METHOD_DURATION:
+            query_str['sort_by'] = ':'.join((sort_field, order, 'float'))
+        else:
+            query_str['sort_by'] = ':'.join((sort_field, order))
 
     return _get_url_page('stories', page, items_per_page, params=query_str)

--- a/plugin.video.cinetree/resources/settings.xml
+++ b/plugin.video.cinetree/resources/settings.xml
@@ -10,7 +10,34 @@
 					<control type="toggle"/>
 				</setting>
 			</group>
-			<group id="grp2" label="3110">
+			<group id="grp2" label="30105">
+				<setting id="genre-sort-method" type="integer" label="30106" help="">
+					<level>0</level>
+					<default>0</default>
+					<constraints>
+						<options>
+							<option label="571">40</option>
+							<option label="556">9</option>
+							<option label="570">21</option>
+							<option label="180">8</option>
+							<option label="562">18</option>
+						</options>
+					</constraints>
+					<control type="spinner" format="string"/>
+				</setting>
+				<setting id="genre-sort-order" type="integer" label="30107" help="">
+					<level>0</level>
+					<default>0</default>
+					<constraints>
+						<options>
+							<option label="584">0</option>
+							<option label="585">1</option>
+						</options>
+					</constraints>
+					<control type="spinner" format="string"/>
+				</setting>
+			</group>
+			<group id="grp3" label="30110">
 				<setting id="log-handler" label="30111" type="string" help="">
 					<level>2</level>
 					<default>Kodi log</default>
@@ -38,7 +65,7 @@
         </category>
         <!-- Cinetree account -->
         <category id="account" label="30200" help="">
-			<group id="grp3">
+			<group id="grp4">
 				<setting id="ct-log-in" label="30201" type="action" help="">
 					<level>0</level>
 					<data>RunPlugin(plugin://$ID/resources/lib/settings/login)</data>

--- a/tests/local/test_settings.py
+++ b/tests/local/test_settings.py
@@ -1,6 +1,6 @@
 
 # ------------------------------------------------------------------------------
-#  Copyright (c) 2022-2023 Dimitri Kroon.
+#  Copyright (c) 2022-2025 Dimitri Kroon.
 #  This file is part of plugin.video.cinetree.
 #  SPDX-License-Identifier: GPL-2.0-or-later.
 #  See LICENSE.txt
@@ -61,3 +61,15 @@ class TestSettings(unittest.TestCase):
             with patch.object(logger, 'handlers', new=[py_logging.Handler()]):
                 settings.change_logger(MagicMock())
                 p_ask.assert_called_with(0)
+
+    @patch("xbmcaddon.Addon.setSettingInt")
+    def test_genre_sort_method(self, p_xbmc_settings):
+        with patch("xbmcgui.Dialog.contextmenu", side_effect=(0, 1, 2, 3, 4, 5, 6, 7, 8)):
+            for _ in range(9):
+                settings.genre_sort_method.test()
+        self.assertEqual(p_xbmc_settings.call_count, 18)
+        # Dialog canceled
+        p_xbmc_settings.reset_mock()
+        with patch("xbmcgui.Dialog.contextmenu", return_value=-1):
+            settings.genre_sort_method.test()
+        p_xbmc_settings.assert_not_called()

--- a/tests/web/test_main_web.py
+++ b/tests/web/test_main_web.py
@@ -10,7 +10,7 @@ from tests.support import fixtures
 fixtures.global_setup()
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import xbmcgui
 
@@ -95,13 +95,15 @@ class MainTest(unittest.TestCase):
         playitem = main.play_film.test('', '63c77a7f-c84b-4143-9cda-68a99c042fe9', None)
         self.assertIsInstance(playitem, xbmcgui.ListItem)
 
-    def test_list_genre_drama(self):
+    @patch('xbmcaddon.Addon.getSetting', return_value='0')
+    def test_list_genre_drama(self, _):
         """As there are a lot of film in genre drama, only the maximum of 50 per page ar returned."""
         items = main.list_films_by_genre.test(genre='drama')
         self.assertAlmostEqual(51, len(items), delta=10)       # some films can be filtered out on expired endDate
         self.assertLessEqual(len(items), 51)
 
-    def test_list_genre_documentaries(self):
+    @patch('xbmcaddon.Addon.getSetting', return_value='0')
+    def test_list_genre_documentaries(self, _):
         """As there are a lot of film in genre drama, only the maximum of 50 per page ar returned."""
         items = list(main.list_films_by_genre.test(genre='documentary'))
         self.assertAlmostEqual(51, len(items), delta=10)       # some films can be filtered out on expired endDate

--- a/tests/web/test_storyblok_api.py
+++ b/tests/web/test_storyblok_api.py
@@ -15,6 +15,8 @@ import json
 import time
 from unittest import TestCase
 
+import xbmcplugin
+
 from resources.lib import storyblok
 from resources.lib.ctree import ct_api
 from resources.lib.ctree import ct_data
@@ -227,3 +229,40 @@ class Search(TestCase):
 
     def test_search_nothing(self):
         self.assertRaises(ValueError, storyblok.search)
+
+    def test_search_sorted_ascending(self):
+        film_list, num_films = storyblok.search(search_term='is',
+                                                sort_method=xbmcplugin.SORT_METHOD_TITLE)
+        self.assertEqual(num_films, len(film_list))
+        prev_title = ''
+        for film in film_list:
+            # Cinetree sorts case-insensitive and ignores non-alphabetical characters
+            title = film['content']['title'].replace(' ', '').replace("'", '').replace(',', '').lower()
+            self.assertTrue(title >= prev_title)
+            prev_title = title
+
+    def test_search_sorted_decending(self):
+        film_list, num_films = storyblok.search(search_term='is',
+                                                sort_method=xbmcplugin.SORT_METHOD_TITLE,
+                                                sort_order=1)
+        self.assertEqual(num_films, len(film_list))
+        prev_title = 'zzzzzzzzzz'
+        for film in film_list:
+            # Cinetree sorts case-insensitive and ignores non-alphabetical characters
+            title = film['content']['title'].replace(' ', '').replace("'", '').replace(',', '').lower()
+            self.assertTrue(title <= prev_title)
+            prev_title = title
+
+    def test_search_sort_on_duration(self):
+        film_list, num_films = storyblok.search(genre='Documentary',
+                                                sort_method=xbmcplugin.SORT_METHOD_DURATION,
+                                                sort_order=0)
+        self.assertEqual(num_films, len(film_list))
+        prev_duration = 0
+        i = 0
+        for film in film_list:
+            # Cinetree sorts case-insensitive and ignores non-alphabetical characters
+            duration = float(film['content']['duration'].split()[0])
+            self.assertTrue(duration >= prev_duration)
+            prev_duration = duration
+            i += 1


### PR DESCRIPTION
Since genres often produce multiple pages, letting Kodi sort a single page from an unsorted list does not produce the desired result.

This PR allows to sort genres listings at the web service. Some extra settings in the Addon are now available to define the sort method and direction. Additionally, each entry in a genre listing has a context menu item where the sort settings can be changed. 
These settings apply to all genre listings, but to genres alone. All other listing can be sorted by Kodi the usual way; the option 'sort by' and 'order' in the side menu.