### PR TITLE
Detect running an outdate version.

### DIFF
--- a/plugin.video.cinetree/resources/lib/main.py
+++ b/plugin.video.cinetree/resources/lib/main.py
@@ -7,6 +7,8 @@
 # ------------------------------------------------------------------------------
 from __future__ import annotations
 
+import xbmcaddon
+
 import xbmc
 import xbmcplugin
 import sys
@@ -28,6 +30,11 @@ from resources.lib import constants
 from resources.lib import utils
 
 
+running_version = utils.addon_info['version']
+
+
+logger.critical('-------------------------------------')
+logger.critical('--- version: %s', running_version)
 logger.critical('-------------------------------------')
 
 TXT_SORT_BY = 30106
@@ -463,3 +470,13 @@ def pay_from_ct_credit(title, uuid):
 def run():
     if isinstance(cc_run(), Exception):
         xbmcplugin.endOfDirectory(int(sys.argv[1]), False)
+    # Due to reuselanguageinvoker the addon may have been updated, while it still
+    # keeps running the old version. Exit with non-zero status to force the current
+    # LanguageInvoker thread to end.
+    installed_version = xbmcaddon.Addon().getAddonInfo('version')
+    if running_version != installed_version:
+        logger.warning("Detected add-on upgrade to %s while still running %s. "
+                       "Exiting non-zero now to end this LanguageInvoker thread",
+                       installed_version,
+                       running_version)
+        sys.exit(1)

--- a/tests/local/test_main.py
+++ b/tests/local/test_main.py
@@ -403,3 +403,21 @@ class SyncWatchedState(unittest.TestCase):
                 patch('resources.lib.main.PersistentDict._load', return_value={}) as p_load:
             main.sync_watched_state()
             p_load.assert_not_called()
+
+
+class Run(unittest.TestCase):
+    @patch('sys.argv', return_value=['script', '1'])
+    @patch('resources.lib.main.cc_run', return_value=ValueError())
+    @patch('xbmcplugin.endOfDirectory')
+    def test_run_failure(self, p_end_of_dir, _, __):
+        main.run()
+        p_end_of_dir.assert_called_once_with(1, False)
+
+    @patch('resources.lib.main.cc_run', return_value=None)
+    @patch.object(main, 'running_version', '1.0.0')
+    @patch('xbmcaddon.Addon.getAddonInfo', lambda _, s: '2.0.0' if s == 'version' else '')
+    def test_run_outdated_version(self, _):
+        with self.assertRaises(SystemExit) as cm:
+            main.run()
+        err = cm.exception
+        self.assertEqual(1, err.code)


### PR DESCRIPTION
Due to the use of reuselanguageinvoker the add-on may have been updated while still running the previous version. 
This PR checks if a new version has been installed and forces a reload of the add-on.